### PR TITLE
[JNI] Support auto-build the jni/jmh dependency for  java usage

### DIFF
--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -1,0 +1,116 @@
+name: "topling java"
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository_url:
+        required: true
+        default: 'distributedStorage/toplingdb'
+      repository_branch:
+        required: false
+        default: 'sideplugin-7.10.0-2022-12-21-bec42648'
+      test:
+        required: false
+        type: boolean
+        description: test SideGetBenchmarks
+        default: false
+      deploy_maven:
+        required: false
+        type: boolean
+        description: publish to maven nexus
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GCC_VER: "11.3" # better get from the 'gcc --version'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository_url }}
+          ref: ${{ inputs.repository_branch }}
+          fetch-depth: 1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+      #- name: Cache Make
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: ~/.m2/repository
+      #    key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+      #    restore-keys: ${{ runner.os }}-m2
+          
+      - name: Init Env & Compile RocksDB
+        run: |
+         cat $GITHUB_WORKSPACE/settings.xml
+         sudo apt-get update -y && sudo apt-get install -y \
+         libjemalloc-dev libaio-dev libgflags-dev zlib1g-dev \
+         libbz2-dev libcurl4-gnutls-dev liburing-dev
+         gcc --version
+         git submodule update --init --recursive
+         mkdir -p ~/.ssh && mkdir -p /opt/lib
+         ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+         # this step could take a long time?
+         make -j`nproc` DEBUG_LEVEL=0 shared_lib
+         sudo make install-shared PREFIX=/opt
+         ls -l /opt/lib
+
+      - name: Compile RocksDBJava
+        run: |
+          echo $JAVA_HOME && ls -l $(which jps)
+          make rocksdbjava -j`nproc` DEBUG_LEVEL=0
+
+      - name: Move to Local Maven Repo
+        run: |
+          cd java/target || exit
+          cp -v rocksdbjni-7.10.0-linux64.jar rocksdbjni-7.10.0-SNAPSHOT-linux64.jar
+          mvn install:install-file -ntp -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar \
+          -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
+
+      # for compile SideGetBenchmarks
+      - name: Build SideGetBenchmarks with Maven
+        run: |
+          echo ${{ github.workspace }} && echo $GITHUB_WORKSPACE
+          pwd && ls -l
+          (cd java/jmh && ls -l && pwd) || exit
+          mvn clean package -e -ntp -f $GITHUB_WORKSPACE/java/jmh/pom.xml # -B in non-interactive (Batch) mode
+          
+      - name: Run SideGetBenchmarks & Check it
+        if: ${{ inputs.test }}
+        run: |
+          mkdir -p /dev/shm/db_bench_community
+          cd $GITHUB_WORKSPACE/java/jmh || exit
+          ls ../../sideplugin/rockside/src/topling/web
+          cp -v $GITHUB_WORKSPACE/sideplugin/rockside/src/topling/web/{style.css,index.html} /dev/shm/db_bench_community
+          echo $LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=/opt/lib:$LD_LIBRARY_PATH # for libterark-*
+          echo $LD_LIBRARY_PATH && ls -l /opt/lib
+          #export LD_PRELOAD=libterark-zbs-g++-12.1-r.so:libterark-fsa-g++-12.1-r.so:libjemalloc.so # not exist
+          export LD_PRELOAD=libterark-zbs-g++-11.3-r.so:libterark-fsa-g++-11.3-r.so:libjemalloc.so
+          java -jar target/rocksdbjni-jmh-1.0-SNAPSHOT-benchmarks.jar \
+               -p keyCount=1000 -p keySize=128 -p valueSize=32768 \
+               -p sideConf=$GITHUB_WORKSPACE/sideplugin/rockside/sample-conf/db_bench_community.yaml SideGetBenchmarks
+          # curl http://127.0.0.1:2011 # web server should visit in running time
+          
+      #- if: ${{ inputs.deploy_maven }} 
+      #  uses: s4u/maven-settings-action@v2.8.0 # seems "actions/setup-java" could include this
+      - name: Publish JAR to GitHub Packages
+        if: ${{ inputs.deploy_maven }}
+        run: |
+          cd $GITHUB_WORKSPACE/java/jmh || exit
+          ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
+          mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -1,3 +1,4 @@
+# TODO: How to cache make files / speed up build progress here?
 name: "topling java"
 
 on:
@@ -46,7 +47,7 @@ jobs:
           cache: maven
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
-      #- name: Cache Make
+      #- name: Cache Maven # Replace by setup-java now
       #  uses: actions/cache@v3
       #  with:
       #    path: ~/.m2/repository
@@ -77,15 +78,15 @@ jobs:
         run: |
           cd java/target || exit
           cp -v rocksdbjni-7.10.0-linux64.jar rocksdbjni-7.10.0-SNAPSHOT-linux64.jar
+          mvn install:install-file -ntp -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar \
+          -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
+          # TODO: why deploy doesn't include install step here? if we only use deploy, will lack local jar
           if [ ${{ inputs.deploy_maven }} ]; then
             # TODO: what's the pom file for it? -DpomFile=/xx/pom.xml 
             mvn deploy:deploy-file -e -s $GITHUB_WORKSPACE/settings.xml \
             -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github \
             -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb \
             -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
-          else
-            mvn install:install-file -ntp -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar \
-            -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
           fi
 
       # for compile SideGetBenchmarks
@@ -112,9 +113,7 @@ jobs:
                -p keyCount=1000 -p keySize=128 -p valueSize=32768 \
                -p sideConf=$GITHUB_WORKSPACE/sideplugin/rockside/sample-conf/db_bench_community.yaml SideGetBenchmarks
           # curl http://127.0.0.1:2011 # web server should visit in running time
-          
-      #- if: ${{ inputs.deploy_maven }} 
-      #  uses: s4u/maven-settings-action@v2.8.0 # seems "actions/setup-java" could include this
+
       - name: Publish JAR to GitHub Packages
         if: ${{ inputs.deploy_maven }}
         run: |

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -69,15 +69,23 @@ jobs:
 
       - name: Compile RocksDBJava
         run: |
-          echo $JAVA_HOME && ls -l $(which jps)
+          echo $JAVA_HOME
           make rocksdbjava -j`nproc` DEBUG_LEVEL=0
 
       - name: Move to Local Maven Repo
         run: |
           cd java/target || exit
           cp -v rocksdbjni-7.10.0-linux64.jar rocksdbjni-7.10.0-SNAPSHOT-linux64.jar
-          mvn install:install-file -ntp -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar \
-          -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
+          if [ ${{ inputs.deploy_maven }} ]; then
+            # TODO: what's the pom file for it? -DpomFile=/xx/pom.xml 
+            mvn deploy:deploy-file -e -s $GITHUB_WORKSPACE/settings.xml \
+            -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github \
+            -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb \
+            -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
+          else
+            mvn install:install-file -ntp -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar \
+            -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
+          fi
 
       # for compile SideGetBenchmarks
       - name: Build SideGetBenchmarks with Maven
@@ -112,6 +120,7 @@ jobs:
           cd $GITHUB_WORKSPACE/java/jmh || exit
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
-                     -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb
+          -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
+          # -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # TODO: failed with it now
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GCC_VER: "11.3" # better get from the 'gcc --version'
+      GITHUB_TOKEN: ${{ github.token }}
     permissions:
       contents: read
       packages: write
@@ -123,5 +124,5 @@ jobs:
           -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
           # -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
           # -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb # TODO: try it later
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        #env:
+        #  GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -121,7 +121,7 @@ jobs:
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
           -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb
-          -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
+          #-Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
           #-Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
         #env:
         #  GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/java/jmh || exit
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
-          mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml
+          mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
+                     -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -121,6 +121,7 @@ jobs:
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
           -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
-          # -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # TODO: failed with it now
+          # -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
+          # -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb # TODO: try it later
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-java.yml
+++ b/.github/workflows/topling-java.yml
@@ -120,8 +120,8 @@ jobs:
           cd $GITHUB_WORKSPACE/java/jmh || exit
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
-          -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
-          # -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
-          # -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb # TODO: try it later
+          -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb
+          -Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
+          #-Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
         #env:
         #  GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -85,7 +85,7 @@ jobs:
           if [ ${{ inputs.deploy_maven }} ]; then
             # TODO: what's the pom file for it? add with '-DpomFile=/xx/pom.xml'
             mvn deploy:deploy-file -e -s $GITHUB_WORKSPACE/settings.xml \
-            -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/toplingdb/toplingdb -DrepositoryId=github \
             -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb \
             -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
           fi
@@ -120,6 +120,6 @@ jobs:
           cd $GITHUB_WORKSPACE/java/jmh || exit
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
-          -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb
+          -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/toplingdb/toplingdb
         #env:
         #  GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -18,7 +18,7 @@ on:
       deploy_maven:
         required: false
         type: boolean
-        description: publish to maven nexus
+        description: publish to maven repo
         default: false
 
 jobs:

--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -1,12 +1,12 @@
 # TODO: How to cache make files / speed up build progress here?
-name: "topling java"
+name: "build topling-jni"
 
 on:
   workflow_dispatch:
     inputs:
       repository_url:
         required: true
-        default: 'distributedStorage/toplingdb'
+        default: 'toplingdb/toplingdb'
       repository_branch:
         required: false
         default: 'sideplugin-7.10.0-2022-12-21-bec42648'
@@ -23,9 +23,10 @@ on:
 
 jobs:
   build:
+    # refer https://github.com/actions/runner-images to get the details
     runs-on: ubuntu-latest
     env:
-      GCC_VER: "11.3" # better get from the 'gcc --version'
+      GCC_VER: "11.3" # TODO: better get from the 'gcc --version'
       GITHUB_TOKEN: ${{ github.token }}
     permissions:
       contents: read
@@ -82,14 +83,14 @@ jobs:
           -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
           # TODO: why deploy doesn't include install step here? if we only use deploy, will lack local jar
           if [ ${{ inputs.deploy_maven }} ]; then
-            # TODO: what's the pom file for it? -DpomFile=/xx/pom.xml 
+            # TODO: what's the pom file for it? add with '-DpomFile=/xx/pom.xml'
             mvn deploy:deploy-file -e -s $GITHUB_WORKSPACE/settings.xml \
             -Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github \
             -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb \
             -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
           fi
 
-      # for compile SideGetBenchmarks
+      # for compile jmh.jar to test the performance
       - name: Build SideGetBenchmarks with Maven
         run: |
           echo ${{ github.workspace }} && echo $GITHUB_WORKSPACE
@@ -107,12 +108,11 @@ jobs:
           echo $LD_LIBRARY_PATH
           export LD_LIBRARY_PATH=/opt/lib:$LD_LIBRARY_PATH # for libterark-*
           echo $LD_LIBRARY_PATH && ls -l /opt/lib
-          #export LD_PRELOAD=libterark-zbs-g++-12.1-r.so:libterark-fsa-g++-12.1-r.so:libjemalloc.so # not exist
+          # Note: webserver should visit while running
           export LD_PRELOAD=libterark-zbs-g++-11.3-r.so:libterark-fsa-g++-11.3-r.so:libjemalloc.so
           java -jar target/rocksdbjni-jmh-1.0-SNAPSHOT-benchmarks.jar \
                -p keyCount=1000 -p keySize=128 -p valueSize=32768 \
                -p sideConf=$GITHUB_WORKSPACE/sideplugin/rockside/sample-conf/db_bench_community.yaml SideGetBenchmarks
-          # curl http://127.0.0.1:2011 # web server should visit in running time
 
       - name: Publish JAR to GitHub Packages
         if: ${{ inputs.deploy_maven }}
@@ -121,7 +121,5 @@ jobs:
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
           -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/distributedStorage/toplingdb
-          #-Dregistry=https://maven.pkg.github.com/distributedStorage/toplingdb # <- failed with it
-          #-Durl=https://maven.pkg.github.com/distributedStorage/toplingdb -DrepositoryId=github
         #env:
         #  GITHUB_TOKEN: ${{ github.token }}

--- a/java/jmh/pom.xml
+++ b/java/jmh/pom.xml
@@ -140,7 +140,7 @@
     <repository>
       <id>github</id>
       <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/distributedStorage/toplingdb</url>
+      <url>https://maven.pkg.github.com/toplingdb/toplingdb</url>
     </repository>
   </distributionManagement-->
 

--- a/java/jmh/pom.xml
+++ b/java/jmh/pom.xml
@@ -136,12 +136,12 @@
     </build>
 
   <!-- add github maven config for deploy(upload) packages -->
-  <distributionManagement>
+  <!--distributionManagement>
     <repository>
       <id>github</id>
       <name>GitHub Packages</name>
       <url>https://maven.pkg.github.com/distributedStorage/toplingdb</url>
     </repository>
-  </distributionManagement>
+  </distributionManagement-->
 
 </project>

--- a/java/jmh/pom.xml
+++ b/java/jmh/pom.xml
@@ -135,4 +135,13 @@
         </plugins>
     </build>
 
+  <!-- add github maven config for deploy(upload) packages -->
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/distributedStorage/toplingdb</url>
+    </repository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
### Feature desc:

After merge it, we could **manually** `build & test & publish` our `jni` dependencies for the toplingdb, and all of the users could also modify it by themselves easily

Basic usage:
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/17706099/229287948-5cea1f3f-9ce5-4ee2-ad76-5635fd6fdbce.png">

TODOs:
- [ ] speed up / cache the compile time for the 1st `make` step
- [ ] it's optional choose to trigger it by `git push` (new commit) 
- [ ] we need specify a `pom.xml` for the `rocksdb-jni.jar` (#45 )
- [ ] we need java-source-doc for `rocksdb-jni` to read source code (Lack it now)

BTW, use the PR title as the commit message with`squash and merge` option