### PR TITLE
fix: unify repo url for topling-jni action

### DIFF
--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       GCC_VER: "11.3" # TODO: better get from the 'gcc --version'
       GITHUB_TOKEN: ${{ github.token }}
+      REP_URL: ${{ inputs.repository_url }}
     permissions:
       contents: read
       packages: write
@@ -36,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.repository_url }}
+          repository: $REP_URL
           ref: ${{ inputs.repository_branch }}
           fetch-depth: 1
 
@@ -81,13 +82,13 @@ jobs:
           cp -v rocksdbjni-7.10.0-linux64.jar rocksdbjni-7.10.0-SNAPSHOT-linux64.jar
           mvn install:install-file -ntp -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar \
           -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
-          # TODO: why deploy doesn't include install step here? if we only use deploy, will lack local jar
+          # TODO: why 'deploy' doesn't include install step here? if we only use deploy, will lack local jar
           if [ ${{ inputs.deploy_maven }} ]; then
             # TODO: what's the pom file for it? add with '-DpomFile=/xx/pom.xml'
             mvn deploy:deploy-file -e -s $GITHUB_WORKSPACE/settings.xml \
-            -Durl=https://maven.pkg.github.com/toplingdb/toplingdb -DrepositoryId=github \
-            -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb \
-            -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
+                -Durl=https://maven.pkg.github.com/$REP_URL -DrepositoryId=github \
+                -Dfile=rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb \
+                -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
           fi
 
       # for compile jmh.jar to test the performance
@@ -120,6 +121,6 @@ jobs:
           cd $GITHUB_WORKSPACE/java/jmh || exit
           ls -l $GITHUB_WORKSPACE && tail -15 pom.xml
           mvn deploy -e -f $GITHUB_WORKSPACE/java/jmh/pom.xml -s $GITHUB_WORKSPACE/settings.xml \
-          -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/toplingdb/toplingdb
+                     -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/$REP_URL
         #env:
         #  GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: ${{ REP_URL }}
+          repository: ${{ inputs.repository_url }}
           ref: ${{ inputs.repository_branch }}
           fetch-depth: 1
 

--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: $REP_URL
+          repository: ${{ REP_URL }}
           ref: ${{ inputs.repository_branch }}
           fetch-depth: 1
 


### PR DESCRIPTION
Avoid hard code repo in action, merge **after** 
test https://github.com/distributedStorage/toplingdb/actions/runs/4605922917 **passed** 🆗 


**Update:** 
we should not use `bool` in shell  condition with `[]`, maybe try ` if false` instead（thanks @rockeet to point this）

![image](https://user-images.githubusercontent.com/17706099/229750429-8c684492-7bb5-4874-a3c0-a89b5173a059.png)

currently we upload the `jni` dependence to the github maven repo whether we choose it or not 😢 
