### PR TITLE
fix(ci): align JNI LTO compiler

### DIFF
--- a/.github/workflows/topling-jni-release.yml
+++ b/.github/workflows/topling-jni-release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    # Keep the linker compatible with the GCC 13 LTO trial objects.
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-13
+      CXX: g++-13
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/topling-jni.yml
+++ b/.github/workflows/topling-jni.yml
@@ -30,9 +30,11 @@ on:
 jobs:
   build:
     # refer https://github.com/actions/runner-images to get the details
-    runs-on: ubuntu-22.04
+    # Prebuilt trial objects use GCC 13 LTO bytecode.
+    runs-on: ubuntu-24.04
     env:
-      GCC_VER: "11.3" # TODO: better get from the 'gcc --version'
+      CC: gcc-13
+      CXX: g++-13
       GITHUB_TOKEN: ${{ github.token }}
     permissions:
       contents: read


### PR DESCRIPTION
## 0x00 Summary

Align both JNI workflows with the GCC 13 LTO toolchain used by the prebuilt CSPP trial objects.

| Before | After |
| --- | --- |
| GCC 11 linked GCC 13 LTO objects | Ubuntu 24.04 with explicit `gcc-13` / `g++-13` |

## 0x01 Root cause

The prebuilt `cspp_memtable.o` contains GCC 13.1 LTO bytecode, while the previous JNI workflow linked it with GCC 11.3:

```text
lto1: bytecode stream ... generated with LTO version 13.1
instead of the expected 11.3
```

## 0x02 Scope

- Update `topling-jni.yml`
- Update `topling-jni-release.yml`
- Keep `Makefile` unchanged

The non-fatal `make depend` errors are handled upstream by `635f082` (`ci(jni): ignore explicit make depend failures`).

## 0x03 Validation

- Rebased onto `635f082`
- `git diff --check`
- PR diff contains only the two JNI workflows
